### PR TITLE
Support MDList categories and fix tutorial bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,18 +435,31 @@ home.fill().then(()=>{
 |manga|```Array<Manga>```| All manga in this MDList
 |banner|```String```| Partial url to the MDList header banner (use getFullURL())
 
-### ```Promise fill(id, [order])```
+### MDList.category
+|Name|Value
+|-|-
+|ALL|0
+|READING|1
+|COMPLETED|2
+|ON_HOLD|3
+|PLAN_TO_READ|4
+|DROPPED|5
+|RE_READING|6
+
+### ```Promise fill(id, [category], [order])```
 |Arguments|Type|Informaation|Optional
 |-|-|-|-
 |ID|```Number```| MangaDex Object ID | No
+|Category|```MDList.category```| Mangadex follow category | Yes
 |Order|```Number|String```| Order of the returned list (see ```enum/listing-order.js```) | Yes
 
 Calls and fills object with info from MangaDex return. Promise returns the object.
 
-### ```Promise fillByUser(user, [order])```
+### ```Promise fillByUser(user, [category], [order])```
 |Arguments|Type|Informaation|Optional
 |-|-|-|-
 |User|```User```| MangaDex User Object | No
+|Category|```MDList.category```| Mangadex follow category | Yes
 |Order|```Number|String```| Order of the returned list (see ```enum/listing-order.js```) | Yes
 
 Uses a user object to execute fill() on their MDList.
@@ -461,7 +474,7 @@ Returns the full URL of a partially stored one.
 ```javascript
 
 let list = new MDList();
-await list.fill(LIST_ID, listingOrder["Follows (Des)"]);
+await list.fill(LIST_ID, MDList.category.ALL, listingOrder["Follows (Des)"]);
 console.log(`There are ${list.manga.length} manga in this MDList.`)
 
 ```

--- a/README.md
+++ b/README.md
@@ -435,32 +435,21 @@ home.fill().then(()=>{
 |manga|```Array<Manga>```| All manga in this MDList
 |banner|```String```| Partial url to the MDList header banner (use getFullURL())
 
-### MDList.category
-|Name|Value
-|-|-
-|ALL|0
-|READING|1
-|COMPLETED|2
-|ON_HOLD|3
-|PLAN_TO_READ|4
-|DROPPED|5
-|RE_READING|6
-
-### ```Promise fill(id, [category], [order])```
+### ```Promise fill(id, [order], [category])```
 |Arguments|Type|Informaation|Optional
 |-|-|-|-
 |ID|```Number```| MangaDex Object ID | No
-|Category|```MDList.category```| Mangadex follow category | Yes
 |Order|```Number|String```| Order of the returned list (see ```enum/listing-order.js```) | Yes
+|Category|```Number```| Category of the returned list (eg Dropped and Re-Reading) (see ```enum/viewing-categories.js```) | Yes
 
 Calls and fills object with info from MangaDex return. Promise returns the object.
 
-### ```Promise fillByUser(user, [category], [order])```
+### ```Promise fillByUser(user, [order], [category])```
 |Arguments|Type|Informaation|Optional
 |-|-|-|-
 |User|```User```| MangaDex User Object | No
-|Category|```MDList.category```| Mangadex follow category | Yes
 |Order|```Number|String```| Order of the returned list (see ```enum/listing-order.js```) | Yes
+|Category|```Number```| Category of the returned list (eg Dropped and Re-Reading) (see ```enum/viewing-categories.js```) | Yes
 
 Uses a user object to execute fill() on their MDList.
 
@@ -474,8 +463,8 @@ Returns the full URL of a partially stored one.
 ```javascript
 
 let list = new MDList();
-await list.fill(LIST_ID, MDList.category.ALL, listingOrder["Follows (Des)"]);
-console.log(`There are ${list.manga.length} manga in this MDList.`)
+await list.fill(LIST_ID, listingOrder["Follows (Des)"], viewingCategories.DROPPED);
+console.log(`There are ${list.manga.length} dropped manga in this MDList.`)
 
 ```
 

--- a/src/enum/viewing-categories.js
+++ b/src/enum/viewing-categories.js
@@ -1,0 +1,13 @@
+/**
+ * Categories used for follows and MDLists
+ * @enum {Number}
+ */
+module.exports = {
+    ALL: 0,
+    READING: 1,
+    COMPLETED: 2,
+    ON_HOLD: 3,
+    PLAN_TO_READ: 4,
+    DROPPED: 5,
+    RE_READING: 6
+};

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ module.exports = {
     demographic: require("./enum/demographic"),
     pubStatus: require("./enum/pubstatus"),
     listingOrder: require("./enum/listing-order"),
+    viewingCategories: require("./enum/viewing-categories"),
 
     // Re-add to maintain hints
     agent: agentInstance

--- a/src/structure/mdlist.js
+++ b/src/structure/mdlist.js
@@ -83,6 +83,9 @@ class MDList extends APIObject {
             let totalTitles = initalMatches.titles;
             let totalManga = initalMatches.manga;
 
+            // Remove Tutorial
+            if (initalMatches.manga[0] == "30461") initalMatches.manga.splice(0, 1);
+            
             // Skip first page (already called above)
             for (let page = 2; page <= pages; page++) {
                 let matches = await Util.getMatches(web + page.toString(), matchObject);

--- a/src/structure/mdlist.js
+++ b/src/structure/mdlist.js
@@ -7,6 +7,16 @@ const listOrder = require("../enum/listing-order");
  * Represents a MangaDex MDList
  */
 class MDList extends APIObject {
+    static category = {
+        ALL: 0,
+        READING: 1,
+        COMPLETED: 2,
+        ON_HOLD: 3,
+        PLAN_TO_READ: 4,
+        DROPPED: 5,
+        RE_READING: 6
+    };
+
     _parse(data) {
         /**
          * MangaDex MDList ID
@@ -33,9 +43,10 @@ class MDList extends APIObject {
     }
 
     /**
+     * @param {Category} category Mangadex follow category. Default: category.ALL
      * @param {Number|String} order Order of the list, specified by the enum 'listingOrder.'
      */
-    fill(id, order = 0) {
+    fill(id, category = MDList.category.ALL, order = 0) {
         if (!id) id = this.id;
 
         if (typeof order === "string") {
@@ -45,7 +56,7 @@ class MDList extends APIObject {
 
         return new Promise(async (resolve, reject) => {
             if (!id) reject("No id specified or found.");
-            const web = `https://mangadex.org/list/${id}/0/${order}/`;
+            const web = `https://mangadex.org/list/${id}/${category}/${order}/`;
 
             let matchObject = {
                 "titles": /<a[^>]*class="[^"]*manga_title[^"]*"[^>]*>([^<]*)</gmi,
@@ -71,7 +82,7 @@ class MDList extends APIObject {
             if (!initalMatches.titles || !initalMatches.manga) reject("Could not find manga details.");
             let totalTitles = initalMatches.titles;
             let totalManga = initalMatches.manga;
-            
+
             // Skip first page (already called above)
             for (let page = 2; page <= pages; page++) {
                 let matches = await Util.getMatches(web + page.toString(), matchObject);
@@ -105,10 +116,11 @@ class MDList extends APIObject {
     /**
      * Requests a MDList from a user account.
      * @param {User} user MangaDex User Object
+     * @param {Category} category Mangadex follow category. Default: category.ALL
      * @param {Number|String} order The list order (enum/listing-order)
      */
-    fillByUser(user, order) {
-        return this.fill(user.id, order);
+    fillByUser(user, category, order) {
+        return this.fill(user.id, category, order);
     }
 
     /**

--- a/src/structure/mdlist.js
+++ b/src/structure/mdlist.js
@@ -2,21 +2,12 @@ const APIObject = require("./apiobject");
 const Util = require("../util");
 const Manga = require("./manga");
 const listOrder = require("../enum/listing-order");
+const viewingCategory = require("../enum/viewing-categories");
 
 /**
  * Represents a MangaDex MDList
  */
 class MDList extends APIObject {
-    static category = {
-        ALL: 0,
-        READING: 1,
-        COMPLETED: 2,
-        ON_HOLD: 3,
-        PLAN_TO_READ: 4,
-        DROPPED: 5,
-        RE_READING: 6
-    };
-
     _parse(data) {
         /**
          * MangaDex MDList ID
@@ -43,16 +34,17 @@ class MDList extends APIObject {
     }
 
     /**
-     * @param {Category} category Mangadex follow category. Default: category.ALL
      * @param {Number|String} order Order of the list, specified by the enum 'listingOrder.'
+     * @param {Number} category Mangadex follow category. Default: All. See enum 'viewingCategories'
      */
-    fill(id, category = MDList.category.ALL, order = 0) {
+    fill(id, order = 0, category = viewingCategory.ALL) {
         if (!id) id = this.id;
 
         if (typeof order === "string") {
             if (order in listOrder) order = listOrder[order];
             else order = 0;
         }
+        if (!(category in Object.values(viewingCategory))) category = 0;
 
         return new Promise(async (resolve, reject) => {
             if (!id) reject("No id specified or found.");
@@ -84,7 +76,7 @@ class MDList extends APIObject {
             let totalManga = initalMatches.manga;
 
             // Remove Tutorial
-            if (initalMatches.manga[0] == "30461") initalMatches.manga.splice(0, 1);
+            if (totalManga[0] == "30461") totalManga.splice(0, 1);
             
             // Skip first page (already called above)
             for (let page = 2; page <= pages; page++) {
@@ -119,11 +111,11 @@ class MDList extends APIObject {
     /**
      * Requests a MDList from a user account.
      * @param {User} user MangaDex User Object
-     * @param {Category} category Mangadex follow category. Default: category.ALL
      * @param {Number|String} order The list order (enum/listing-order)
+     * @param {Number} category Mangadex follow category. Default: All. See enum 'viewingCategories'
      */
-    fillByUser(user, category, order) {
-        return this.fill(user.id, category, order);
+    fillByUser(user, order, category) {
+        return this.fill(user.id, order, category);
     }
 
     /**


### PR DESCRIPTION
Added an MDList category enum object, used category enum in MDList lookup, and modified the documentation to reflect this change.

I also fixed a bug where the tutorial manga would show on the first page of results.