### PR TITLE
fixed 404 manga not found

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -41,25 +41,24 @@ module.exports = {
 
                 res.url = url;
                 let payload = "";
+                let contentType = res.headers["content-type"];
 
                 if (res.statusCode == 503 || res.statusCode == 502 || res.statusCode == 403) reject(`MangaDex is currently in DDOS mitigation mode. (Status code ${res.statusCode})`);
                 else if (res.statusCode >= 500) reject(`MangaDex is currently unavailable. (Status code ${res.statusCode})`);
-                //non existing mangas return a 404 but the response has data!
-                //else if (res.statusCode == 404) reject("Cannot reach Mangadex.org (404). Use agent.domainOverride for a mirror.");
+                else if (res.statusCode == 404) {
+                    if (contentType.indexOf("json") == -1) reject("Page not found or the mangadex.org domain is unavailable. (Status code 404)");
+                    else {
+                        let endpointIndex = res.url.indexOf("/api/");
+                        if (endpointIndex == -1) reject("JSON Object unavailable or the mangadex.org domain is unavailable. (Status code 404)");
+                        else reject(`API Object (${res.url.slice(endpointIndex)}) not found or the mangadex.org domain is unavailable. (Status code 404)`);
+                    }
+                }
 
                 res.on('data', (data) => {
                     payload += data;
                 });
 
                 res.on('end', () => {
-                    if (res.statusCode == 404) { //filter 404's
-                        let resJSON = JSON.parse(payload); 
-                        if (resJSON.message) { //message exists
-                            reject(resJSON.message); //reject with message
-                        } else {
-                            reject("Cannot reach Mangadex.org (404). Use agent.domainOverride for a mirror.");  //default for 404
-                        }
-                    }
                     resolve(payload);
                 });
             }).on('error', reject);


### PR DESCRIPTION
If you go to https://mangadex.org/title/38 you can see that the page itself exists but there is simply no manga.
https://mangadex.org/api/v2/manga/38 returns status code 404 AND {"code":404,"status":"error","message":"Manga not found."}
Simple fix