### PR TITLE
Update APIs to use new urls

### DIFF
--- a/bin/check-enums.js
+++ b/bin/check-enums.js
@@ -8,7 +8,7 @@ const checkFunctions = [
     // Tags/Genre
     async function() {
         let oldTags = require("../src/enum/genre");
-        let newTags = await getData("https://mangadex.org/api/v2/tag", "Tags/Genre");
+        let newTags = await getData("https://api.mangadex.org/v2/tag", "Tags/Genre");
 
         let changed = false;
         for (let i of newTags) {
@@ -23,7 +23,7 @@ const checkFunctions = [
     // Categories/Follow Types
     async function() {
         let oldTypes = require("../src/enum/viewing-categories");
-        let newTypes = await getData("https://mangadex.org/api/v2/follows", "Categories/Follow Types");
+        let newTypes = await getData("https://api.mangadex.org/v2/follows", "Categories/Follow Types");
 
         let oldTypesIDs = Object.values(oldTypes);
         let changed = false;

--- a/src/structure/chapter.js
+++ b/src/structure/chapter.js
@@ -121,7 +121,7 @@ class Chapter extends APIObject {
     }
 
     fill(id) {
-        const api = "https://mangadex.org/api/v2/chapter/"; 
+        const api = "https://api.mangadex.org/v2/chapter/"; 
         if (!id) id = this.id;
         else this.id = id;
 

--- a/src/structure/group.js
+++ b/src/structure/group.js
@@ -118,7 +118,7 @@ class Group extends APIObject {
     }
 
     fill(id) {
-        const web = "https://mangadex.org/api/v2/group/"; 
+        const web = "https://api.mangadex.org/v2/group/"; 
         if (!id) id = this.id;
 
         return new Promise(async (resolve, reject) => {

--- a/src/structure/manga.js
+++ b/src/structure/manga.js
@@ -150,9 +150,9 @@ class Manga extends APIObject {
     }
 
     fill(id) {
-        const newAPI = "https://mangadex.org/api/v2/manga/"; 
+        const newAPI = "https://api.mangadex.org/v2/manga/"; 
         // Old API needed for: Chapter list, cover list
-        const oldAPI = "https://mangadex.org/api/manga/";
+        const oldAPI = "https://api.mangadex.org/v1/manga/";
 
         if (!id) id = this.id;
         return new Promise(async (resolve, reject) => {

--- a/src/structure/user.js
+++ b/src/structure/user.js
@@ -81,7 +81,7 @@ class User extends APIObject {
     }
 
     fill(id) {
-        const api = "https://mangadex.org/api/v2/user/"; 
+        const api = "https://api.mangadex.org/v2/user/"; 
         if (!id) id = this.id;
 
         return new Promise(async (resolve, reject) => {


### PR DESCRIPTION
With the API v2 launch ongoing, MangaDex added new URLs for both v1 and v2. As stated here: https://mangadex.org/thread/351011/9#post_4238014, the old v2 API URL (and presumably v1) will be removed about two weeks from now.

Running fulltest.js passes all three tests.