### PR TITLE
Update typings for manga and chapter

### DIFF
--- a/@types/structure/chapter.d.ts
+++ b/@types/structure/chapter.d.ts
@@ -1,3 +1,5 @@
+import Group = require('./group');
+
 export = Chapter;
 /**
  * Represents a Chapter with pages
@@ -48,9 +50,9 @@ declare class Chapter extends APIObject {
     parentMangaID: number;
     /**
      * IDs of translation groups for this chapter
-     * @type {Array<Number>}
+     * @type {Array<Group>}
      */
-    groups: Array<number>;
+    groups: Array<Group>;
     /**
      * Number of comments for this chapter, not manga
      * @type {Number}
@@ -61,7 +63,7 @@ declare class Chapter extends APIObject {
      * @type {Array<String>}
      */
     pages: Array<string>;
-    saverPages: any[];
+    saverPages: Array<string>|undefined;
     /**
      * Viewcount for this chapter
      * @type {Number}

--- a/@types/structure/manga.d.ts
+++ b/@types/structure/manga.d.ts
@@ -77,9 +77,9 @@ declare class Manga extends APIObject {
     /**
      * Links to manga information on other sites.
      * Replaces raw values with enum/link when available, but still uses MangaDex keys.
-     * @type {Array<String>}
+     * @type {Object}
      */
-    links: Array<string>;
+    links: Object;
     /**
      * Basic information about each chapter in this manga.
      * Call fill() on each of these to request more info.
@@ -88,24 +88,24 @@ declare class Manga extends APIObject {
     chapters: Array<Chapter>;
     /**
      * Viewcount
-     * @type {String}
+     * @type {Number}
      */
-    views: string;
+    views: number;
     /**
      * Bayesian Rating
-     * @type {String}
+     * @type {Number}
      */
-    rating: string;
+    rating: number;
     /**
      * Mean Rating
-     * @type {String}
+     * @type {Number}
      */
-    ratingMean: string;
+    ratingMean: number;
     /**
      * Number of Users who have Rated
-     * @type {String}
+     * @type {Number}
      */
-    ratingUserCount: string;
+    ratingUserCount: number;
     /**
      * Alternate Titles
      * @type {Array<String>}

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Returns (up to) the last 10 manga read by the agent as an array.
 |language|```String```| Original language code (e.g. JP, EN, DE). See ```language.js```
 |hentai|```Boolean```| Hentai or not?
 |description|```String```| Formated description string
-|links|```Array<String>```| Array of full URLs to additional links (e.g. MangaUpdates, MAL, BookWalker). See ```links.js```
+|links|```Object```| Full URLs to additional links (e.g. MangaUpdates, MAL, BookWalker). See ```links.js```
 |chapters|```Array<Chapter>```| Array of all chapters for this manga. Contains only minimal information like ID and title; use ```Chapter.fill()``` 
 |views|```Number```| Amount of manga views
 |rating|```Number```| Manga's Bayesian rating

--- a/src/structure/chapter.js
+++ b/src/structure/chapter.js
@@ -75,7 +75,7 @@ class Chapter extends APIObject {
 
         /**
          * IDs of translation groups for this chapter
-         * @type {Array<Number>}
+         * @type {Array<Group>}
          */
         this.groups = [];
         if (data.groups) {

--- a/src/structure/manga.js
+++ b/src/structure/manga.js
@@ -80,7 +80,7 @@ class Manga extends APIObject {
         /**
          * Links to manga information on other sites.
          * Replaces raw values with enum/link when available, but still uses MangaDex keys.
-         * @type {Array<String>}
+         * @type {Object}
          */
         this.links = data.links;
         if (this.links) for (let i in this.links) if (link[i]) this.links[i] = link[i].prefix + this.links[i];
@@ -109,25 +109,25 @@ class Manga extends APIObject {
 
         /**
          * Viewcount
-         * @type {String}
+         * @type {Number}
          */
         this.views = data.views;
 
         /**
          * Bayesian Rating
-         * @type {String}
+         * @type {Number}
          */
         this.rating = data.rating.bayesian;
 
         /**
          * Mean Rating
-         * @type {String}
+         * @type {Number}
          */
         this.ratingMean = data.rating.mean;
 
         /**
          * Number of Users who have Rated
-         * @type {String}
+         * @type {Number}
          */
         this.ratingUserCount = data.rating.users;
 


### PR DESCRIPTION
Some of the defined types were not up to date with what the classes actually contain so I updated them.

Chapter
 - Groups array type fixed
 - saverPages property type changed from any[] to a string array based on the implementation

Manga
 - Links type fixed to be an object instead of a string array (Also fixed links type in README)
 - Ratings and viewcount types changed to Number.