### PR TITLE
Correct type of Chapter.[saver]pageNames

### DIFF
--- a/src/structure/chapter.js
+++ b/src/structure/chapter.js
@@ -79,13 +79,13 @@ class Chapter {
 
         /**
          * Dont Use. This is an array of partial URLs. Use 'getReadablePages()' to retrieve full urls.
-         * @type {String}
+         * @type {String[]}
          */
         this.pageNames = context.data.attributes.data;
 
         /**
          * Dont Use. This is an array of partial URLs. Use 'getReadablePages()' to retrieve full urls.
-         * @type {String}
+         * @type {String[]}
          */
         this.saverPageNames = context.data.attributes.dataSaver;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -310,14 +310,14 @@ declare module 'mangadex-full-api' {
 	    publishAt: Date;
 	    /**
 	     * Dont Use. This is an array of partial URLs. Use 'getReadablePages()' to retrieve full urls.
-	     * @type {String}
+	     * @type {String[]}
 	     */
-	    pageNames: string;
+	    pageNames: string[];
 	    /**
 	     * Dont Use. This is an array of partial URLs. Use 'getReadablePages()' to retrieve full urls.
-	     * @type {String}
+	     * @type {String[]}
 	     */
-	    saverPageNames: string;
+	    saverPageNames: string[];
 	    /**
 	     * Relationships to scanlation groups that are attributed to this chapter
 	     * @type {Relationship[]}


### PR DESCRIPTION
The type of Chapter.pageNames/Chapter.saverPageNames is marked as string type, when it's an array of strings.