### PR TITLE
Make all order parameters optional for Chapter

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -191,11 +191,11 @@ declare module 'mangadex-full-api' {
 	         */
 	        publishAtSince?: string;
 	        order?: {
-	            createdAt: 'asc' | 'desc';
-	            updatedAt: 'asc' | 'desc';
-	            publishAt: 'asc' | 'desc';
-	            volume: 'asc' | 'desc';
-	            chapter: 'asc' | 'desc';
+	            createdAt?: 'asc' | 'desc';
+	            updatedAt?: 'asc' | 'desc';
+	            publishAt?: 'asc' | 'desc';
+	            volume?: 'asc' | 'desc';
+	            chapter?: 'asc' | 'desc';
 	        };
 	        translatedLanguage?: string[];
 	        originalLanguage?: string[];


### PR DESCRIPTION
More type fixes. It looks like the types generation doesn't mark these as optional for some reason, which is probs why they were missed.