### PR TITLE
Move refresh token logic to another method

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -68,6 +68,14 @@ class AuthUtil {
         if (res.isAuthenticated) return AuthUtil.token;
 
         // Refresh token
+        return await AuthUtil.refreshToken();
+    }
+    
+    /**
+     * Refreshes the current token.
+     * @returns {Promise<String>} Returns session token
+     */
+    static async refreshToken() {
         res = await Util.apiRequest('/auth/refresh', 'POST', { token: AuthUtil.cache.refresh });
         if (!('token') in res) throw new APIRequestError('The API did not respond with any tokens when refreshing tokens', APIRequestError.INVALID_RESPONSE);
         AuthUtil.cache.write({ ...res.token, date: Date.now() });


### PR DESCRIPTION
This way, I can call the refresh token method whenever needed, even if I shouldn't need to.