### PR TITLE
Fix getReadChapters

### DIFF
--- a/src/structure/manga.js
+++ b/src/structure/manga.js
@@ -487,7 +487,7 @@ class Manga {
         await AuthUtil.validateTokens();
         let chapterIds = await Util.apiParameterRequest(`/manga/read`, { ids: ids });
         if (!(chapterIds.data instanceof Array)) throw new APIRequestError('The API did not respond with an array when it was expected to', APIRequestError.INVALID_RESPONSE);
-        return Chapter.getMultiple(...chapterIds);
+        return Chapter.getMultiple(...chapterIds.data);
     }
 
     /**

--- a/test/login.test.js
+++ b/test/login.test.js
@@ -18,6 +18,7 @@ describe('Authentication', async function () {
         assert.equal(typeof credentials.password, 'string', 'Password Environment Variable');
         await MFA.login(credentials.username, credentials.password, './test/.md_tokens');
     });
+    
     describe('getLoggedInUser()', function () {
         it('retrieved English chapters from the followed manga feed', async function () {
             let user = await MFA.User.getLoggedInUser();
@@ -42,6 +43,18 @@ describe('Authentication', async function () {
             assert.strictEqual(manga instanceof Array, true);
             assert.strictEqual(manga.length <= 1, true); // Some test users may have no followed manga
             if (manga.length > 0) assert.strictEqual(manga[0] instanceof MFA.Chapter, true);
+        });
+    });
+    describe('getReadChapters()', function () {
+        let targetId = 'f9c33607-9180-4ba6-b85c-e4b5faee7192';
+        it(`got the read chapters of a manga (${targetId})`, async function () {
+            let readChapters = await MFA.Manga.getReadChapters(targetId);
+            assert.strictEqual(Array.isArray(readChapters), true);
+            readChapters.forEach(chapter => {
+                assert.strictEqual(chapter instanceof MFA.Chapter, true);
+                assert.strictEqual(typeof chapter.id, 'string');
+            });
+            
         });
     });
 });

--- a/test/manga.test.js
+++ b/test/manga.test.js
@@ -4,6 +4,13 @@ const MFA = require('../src/index');
 const assert = require('assert');
 const { validateResultsArray } = require('./index.test');
 
+require('dotenv').config();
+
+const credentials = {
+    username: process.env.MFA_TEST_USER,
+    password: process.env.MFA_TEST_PASSWORD
+};
+
 var targetId = 'f9c33607-9180-4ba6-b85c-e4b5faee7192'; // Default, to be overwritten by successful tests
 
 describe('Manga', function () {
@@ -106,6 +113,21 @@ describe('Manga', function () {
             let tag = await MFA.Manga.getTag('oneshot');
             assert.strictEqual(typeof tag.id, 'string');
             assert.strictEqual(tag.localizedName['en'].toLowerCase(), 'oneshot');
+        });
+    });
+    describe('getReadChapters', function () {
+        before(async function () {
+            assert.equal(typeof credentials.username, 'string', 'Username Environment Variable');
+            assert.equal(typeof credentials.password, 'string', 'Password Environment Variable');
+            await MFA.login(credentials.username, credentials.password, './test/.md_tokens');
+        });
+
+        it(`got the read chapters of a manga (${targetId})`, async function() {
+            let readChapters = await MFA.Manga.getReadChapters(targetId);
+            readChapters.forEach(chapter => {
+                assert.strictEqual(chapter instanceof MFA.Chapter, true);
+                assert.strictEqual(typeof chapter.id, 'string');
+            });
         });
     });
 });

--- a/test/manga.test.js
+++ b/test/manga.test.js
@@ -4,13 +4,6 @@ const MFA = require('../src/index');
 const assert = require('assert');
 const { validateResultsArray } = require('./index.test');
 
-require('dotenv').config();
-
-const credentials = {
-    username: process.env.MFA_TEST_USER,
-    password: process.env.MFA_TEST_PASSWORD
-};
-
 var targetId = 'f9c33607-9180-4ba6-b85c-e4b5faee7192'; // Default, to be overwritten by successful tests
 
 describe('Manga', function () {
@@ -113,21 +106,6 @@ describe('Manga', function () {
             let tag = await MFA.Manga.getTag('oneshot');
             assert.strictEqual(typeof tag.id, 'string');
             assert.strictEqual(tag.localizedName['en'].toLowerCase(), 'oneshot');
-        });
-    });
-    describe('getReadChapters', function () {
-        before(async function () {
-            assert.equal(typeof credentials.username, 'string', 'Username Environment Variable');
-            assert.equal(typeof credentials.password, 'string', 'Password Environment Variable');
-            await MFA.login(credentials.username, credentials.password, './test/.md_tokens');
-        });
-
-        it(`got the read chapters of a manga (${targetId})`, async function() {
-            let readChapters = await MFA.Manga.getReadChapters(targetId);
-            readChapters.forEach(chapter => {
-                assert.strictEqual(chapter instanceof MFA.Chapter, true);
-                assert.strictEqual(typeof chapter.id, 'string');
-            });
         });
     });
 });


### PR DESCRIPTION
This PR fixes #64 and adds a test for it.

The test necessitated logging in, since read chapters are not available for logged-out users. This may mean that you have to take your test user and the target manga and go mark some chapters as read for the test to pass. Sorry for the inconvenience!