### PR TITLE
Improve url overrides

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export { default as List } from './shared/List';
 
 // Export specific functions:
 
-export { useDebugServer, overrideApiOrigin, overrideAuthOrigin } from './util/Network';
+export { useDebugServer, overrideApiOrigin, overrideAuthOrigin, getApiOrigin, getAuthOrigin } from './util/Network';
 
 import LocalizedString from './internal/LocalizedString';
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export { default as List } from './shared/List';
 
 // Export specific functions:
 
-export { useDebugServer, overrideApiOrigin, overrideAuthOrigin, getApiOrigin, getAuthOrigin } from './util/Network';
+export { useDebugServer, overrideApiURL, overrideAuthURL, getApiURL, getAuthURL } from './util/Network';
 
 import LocalizedString from './internal/LocalizedString';
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,15 @@ export { default as List } from './shared/List';
 
 // Export specific functions:
 
-export { useDebugServer, overrideApiURL, overrideAuthURL, getApiURL, getAuthURL } from './util/Network';
+export {
+    useDebugServer,
+    overrideApiURL,
+    overrideAuthURL,
+    overrideUploadsURL,
+    getApiURL,
+    getAuthURL,
+    getUploadsURL,
+} from './util/Network';
 
 import LocalizedString from './internal/LocalizedString';
 /**

--- a/src/shared/Cover.ts
+++ b/src/shared/Cover.ts
@@ -6,6 +6,7 @@ import {
     fetchMDDataWithBody,
     fetchMDSearch,
     fetchMDWithFormData,
+    getUploadsURL,
 } from '../util/Network';
 import Relationship from '../internal/Relationship';
 
@@ -85,7 +86,7 @@ export default class Cover extends IDObject implements CoverAttributesSchema {
         this.updatedAt = new Date(schem.attributes.updatedAt);
         const parentRelationship = Relationship.createSelfRelationship('cover_art', this);
         this.manga = Relationship.convertType<Manga>('manga', schem.relationships, parentRelationship).pop()!;
-        this.url = `https://mangadex.org/covers/${this.manga.id}/${this.fileName}`;
+        this.url = `${getUploadsURL()}covers/${this.manga.id}/${this.fileName}`;
         this.uploader = Relationship.convertType<User>('user', schem.relationships).pop() ?? null;
     }
 

--- a/src/util/Network.ts
+++ b/src/util/Network.ts
@@ -59,6 +59,22 @@ export function useDebugServer(val: boolean) {
 }
 
 /**
+ * Returns the origin used for api calls.
+ * https://api.mangadex.org/ by default.
+ */
+export function getApiOrigin() {
+    return NetworkStateManager.apiOrigin;
+}
+
+/**
+ * Returns the origin used for auth calls.
+ * https://auth.mangadex.org/ by default.
+ */
+export function getAuthOrigin() {
+    return NetworkStateManager.authOrigin;
+}
+
+/**
  * Changes the origin used by api calls to a custom one, or clears it if the passed value is undefined.
  * @param domain - The new domain (e.g. https://example.com)
  */

--- a/src/util/Network.ts
+++ b/src/util/Network.ts
@@ -25,6 +25,7 @@ type CustomRequestInit = Omit<RequestInit, 'headers'> & { headers?: Record<strin
 class NetworkStateManager {
     static apiURLOverride: string | undefined;
     static authURLOverride: string | undefined;
+    static uploadsURLOverride: string | undefined;
     static activeClient: IAuthClient | undefined;
 
     static get apiURL() {
@@ -33,6 +34,10 @@ class NetworkStateManager {
 
     static get authURL() {
         return this.authURLOverride ?? 'https://auth.mangadex.org/';
+    }
+
+    static get uploadsURL() {
+        return this.uploadsURLOverride ?? 'https://uploads.mangadex.org/';
     }
 }
 
@@ -74,6 +79,14 @@ export function getAuthURL() {
 }
 
 /**
+ * Returns the URL used for uploads calls.
+ * https://uploads.mangadex.org/ by default.
+ */
+export function getUploadsURL() {
+    return NetworkStateManager.uploadsURL;
+}
+
+/**
  * Changes the origin used by api calls to a custom one, or clears it if the passed value is undefined.
  * @param url - The new URL (e.g. https://example.com)
  */
@@ -96,6 +109,19 @@ export function overrideAuthURL(url: string | undefined) {
         NetworkStateManager.authURLOverride = newUrl.endsWith('/') ? newUrl : newUrl + '/';
     } else {
         NetworkStateManager.authURLOverride = undefined;
+    }
+}
+
+/**
+ * Changes the origin used by uploads calls to a custom one, or clears it if the passed value is undefined.
+ * @param url - The new URL (e.g. https://example.com)
+ */
+export function overrideUploadsURL(url: string | undefined) {
+    if (url) {
+        const newUrl = new URL(url).toString();
+        NetworkStateManager.uploadsURLOverride = newUrl.endsWith('/') ? newUrl : newUrl + '/';
+    } else {
+        NetworkStateManager.uploadsURLOverride = undefined;
     }
 }
 

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -1,4 +1,4 @@
-import { fetchMD, fetchMDAuth, overrideApiOrigin, overrideAuthOrigin, useDebugServer } from '../src/util/Network';
+import { fetchMD, fetchMDAuth, overrideApiURL, overrideAuthURL, useDebugServer } from '../src/util/Network';
 
 function createFetchMock() {
     return jest.fn().mockResolvedValue({
@@ -26,7 +26,7 @@ test('Override Auth Origin', async () => {
     global.fetch = mockFetch;
 
     const testOrigin = 'http://localhost';
-    overrideAuthOrigin(testOrigin);
+    overrideAuthURL(testOrigin);
 
     await fetchMDAuth('/test-endpoint', { param: 'value' });
 
@@ -41,7 +41,7 @@ test('Override Api Origin', async () => {
     global.fetch = mockFetch;
 
     const testOrigin = 'http://localhost';
-    overrideApiOrigin(testOrigin);
+    overrideApiURL(testOrigin);
 
     await fetchMD('/test-endpoint', { param: 'value' });
 


### PR DESCRIPTION
Made getters for currently used URLs globally available.
Accept full URLs instead of just origins for overrides.
Also added an override URL for `https://uploads.mangadex.org` (https://api.mangadex.org/docs/03-manga/covers), but I don't sure about it